### PR TITLE
upd: light cursor in dark style

### DIFF
--- a/haru-dark.css
+++ b/haru-dark.css
@@ -4,6 +4,7 @@
 
 :root {
     --main-color: rgba(128, 30, 255, 1);
+    --cursor-color: rgb(248, 242, 255);
     --shadow-color : rgb(178, 80, 255);
     --dark-main-color: rgb(32, 36, 43);
     --transplate-color : rgba(128, 30, 255, 0.1);
@@ -74,7 +75,7 @@ h1, h2, h3, h4, h5, h6 {
     line-height: 1.6;
     transform: none;
     height: auto;
-    caret-color: var(--main-color);
+    caret-color: var(--cursor-color);
 }
 
 h1, h2, h3,


### PR DESCRIPTION
深色模式下光标与背景颜色相近，难以区分，将光标颜色改为浅色。

修改前：
![](https://raw.githubusercontent.com/Corona09/images/master/cursor-1.png)

修改后：
![](https://raw.githubusercontent.com/Corona09/images/master/cursor-2.png)